### PR TITLE
fix: 添加公司首次配置信息时创建以公司名称命名的根部门

### DIFF
--- a/siteapi/v1/tests/test_config.py
+++ b/siteapi/v1/tests/test_config.py
@@ -67,6 +67,7 @@ class ConfigTestCase(TestCase):
         res = self.client.json_patch(reverse('siteapi:config'),
                                      data={
                                          'company_config': {
+                                             'name_cn': 'demo',
                                              'fullname_cn': 'demo',
                                              'color': 'color',
                                          },
@@ -92,7 +93,7 @@ class ConfigTestCase(TestCase):
 
         expect = {
             'company_config': {
-                'name_cn': '',
+                'name_cn': 'demo',
                 'fullname_cn': 'demo',
                 'name_en': '',
                 'fullname_en': '',
@@ -131,6 +132,7 @@ class ConfigTestCase(TestCase):
                 'is_valid': True,
             },
         }
+
         self.assertEqual(res.json(), expect)
         self.assertEqual(EmailConfig.get_current().access_secret, 'pwd')
         self.assertEqual(SMSConfig.get_current().access_secret, 'pwd')


### PR DESCRIPTION
添加公司首次配置信息时创建以公司名称命名的根部门