### PR TITLE
ci(release): tag src by assigned DEV_VERSION

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM python:3.6 as build_deps
 EXPOSE 80
 WORKDIR /var/oneid
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        vim supervisor gettext
 ADD devops/pip.conf /etc/pip.conf
 ADD requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
@@ -18,10 +21,7 @@ ADD . .
 RUN make test
 
 FROM build_deps as build
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-        vim supervisor gettext \
-    && pip install uwsgi
+RUN pip install uwsgi
 ADD . .
 COPY uwsgi.ini /etc/uwsgi/uwsgi.ini
 RUN \

--- a/devops/jenkinsfile.release
+++ b/devops/jenkinsfile.release
@@ -23,6 +23,12 @@ pipeline {
             returnStdout: true,
             script: "git remote show origin -n |  grep h.URL | sed 's/.*://;s/.git//' ",
         ).trim()}"""
+
+        GIT_SHORT_COMMIT = """${sh(
+            returnStdout: true,
+            script: "echo '${params.DEV_VERSION}' | tr '-' '\\n' | sed -n '\$p'"
+        )}
+        """
     }
     stages {
         stage('pre') {
@@ -97,7 +103,7 @@ def getChangelog(){
 
 def createTag(){
     sh """
-    git tag -f v${params.PROD_VERSION}
+    git tag -f v${params.PROD_VERSION} ${env.GIT_SHORT_COMMIT}
     git push origin v${params.PROD_VERSION}
     """
 }


### PR DESCRIPTION
- 发布release时，代码由镜像版本决定，并不总是HEAD
- 构建时，将 apt-get ... 挪到build_deps 中，虽不太合适，但可以大大加快速度