### PR TITLE
fix(redis): fix redis config not working

### DIFF
--- a/common/redis_utils.py
+++ b/common/redis_utils.py
@@ -25,5 +25,3 @@ class RedisStorage(object):
     def __init__(self, host='localhost', port=6379, db=0, password=None):
         self.pool = redis.ConnectionPool(host=host, port=port, decode_responses=True, password=password)
         self.redisStorage = redis.StrictRedis(connection_pool=self.pool, db=db)
-
-redisStorage = RedisStorage().redisStorage


### PR DESCRIPTION
修复 单例 RedisStorage  被默认值预先初始化，导致自定义配置不生效的bug